### PR TITLE
Kacheln können aufs Feld hinzugefügt werden

### DIFF
--- a/src/main/java/org/example/Spielfeld.java
+++ b/src/main/java/org/example/Spielfeld.java
@@ -1,15 +1,32 @@
 package org.example;
 
+import javax.imageio.ImageIO;
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Random;
 
 public class Spielfeld extends JPanel {
     private static final int ROWS = 14;
     private static final int COLS = 20;
     private static final int CELL_SIZE = 300;
+
     private JPanel[][] cells;
 
+    private List<BufferedImage> tileImages = new ArrayList<>();
+    private BufferedImage selectedTile; // Um das ausgewählte Bild zu speichern
+    private Random random = new Random();
+
     public Spielfeld() {
+        loadTileImages();
         setLayout(new GridLayout(ROWS, COLS));
         cells = new JPanel[ROWS][COLS];
 
@@ -25,9 +42,69 @@ public class Spielfeld extends JPanel {
                 };
                 cell.setPreferredSize(new Dimension(CELL_SIZE, CELL_SIZE));
                 cell.setBackground(Color.WHITE);
+
+                final int finalRow = row;
+                final int finalCol = col;
+
+                // Maus-Listener zur Zelle hinzufügen
+                cell.addMouseListener(new MouseAdapter() {
+                    @Override
+                    public void mouseClicked(MouseEvent e) {
+                        handleCellClick(finalRow, finalCol);
+                    }
+                });
                 cells[row][col] = cell;
                 add(cell);
             }
+        }
+    }
+    private void handleCellClick(int row, int col) {
+        System.out.println("Zelle geklickt: (" + row + ", " + col + ")");
+        Dimension cellSize = cells[row][col].getSize();
+        System.out.println("Zellen-Dimensionen von Zelle "+row+"/"+col+": Breite = " + cellSize.width + ", Höhe = " + cellSize.height);
+
+        applySelectedTileToCell(row,col,cells[row][col].getSize().width,cells[row][col].getSize().height);
+        // Beispiel: Klick führt dazu, dass die Zelle die Farbe ändert
+        //Color currentColor = cells[row][col].getBackground();
+        //if (currentColor.equals(Color.LIGHT_GRAY)) {
+        //    cells[row][col].setBackground(Color.WHITE);
+        //} else {
+        //    cells[row][col].setBackground(Color.LIGHT_GRAY);
+        //}
+    }
+
+    private void loadTileImages() {
+        try {
+            Path tileFolder = Paths.get(getClass().getResource("/tiles").toURI());
+            Files.list(tileFolder).forEach(path -> {
+                try {
+                    tileImages.add(ImageIO.read(path.toFile()));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void showRandomTilePopup() {
+        // Wähle ein zufälliges Bild
+        selectedTile = tileImages.get(random.nextInt(tileImages.size()));
+
+        // Pop-up-Fenster mit dem Bild anzeigen
+        JLabel imageLabel = new JLabel(new ImageIcon(selectedTile));
+        JOptionPane.showMessageDialog(this, imageLabel, "Deine nächste Kachel", JOptionPane.PLAIN_MESSAGE);
+    }
+
+    public void applySelectedTileToCell(int row, int col, int width, int height) {
+        if (selectedTile != null) {
+            Image scaledImage = selectedTile.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+            JLabel label = new JLabel(new ImageIcon(scaledImage));
+            cells[row][col].removeAll();
+            cells[row][col].add(label);
+            cells[row][col].revalidate();
+            cells[row][col].repaint();
         }
     }
 }

--- a/src/main/java/org/example/SwingClientWithBackground.java
+++ b/src/main/java/org/example/SwingClientWithBackground.java
@@ -15,6 +15,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
+import java.awt.image.BufferedImage;
 
 public class SwingClientWithBackground {
 
@@ -87,11 +88,15 @@ public class SwingClientWithBackground {
                     JPanel closepanel = new JPanel();
                     closepanel.setLayout(new FlowLayout(FlowLayout.CENTER));
                     SpielfeldPanel.setPreferredSize(new Dimension(1500, 1000));
+                    JButton spielStartButton = new JButton("Nächste Kachel setzen");
+                    spielStartButton.setPreferredSize(new Dimension(150, 50));
+                    closepanel.add(spielStartButton);
                     //closepanel.setPreferredSize(new Dimension(300, 200));
                     //closepanel.setBorder(BorderFactory.createLineBorder(Color.black));
                     JButton closeButton = new JButton("Zurück zu Windows");
                     closeButton.setPreferredSize(new Dimension(150, 50));
                     closepanel.add(closeButton);
+
 
                     //JLabel label = new JLabel("Funktion noch nicht implementiert", SwingConstants.CENTER);
                     //label.setFont(new Font("Arial", Font.PLAIN, 20));
@@ -99,6 +104,14 @@ public class SwingClientWithBackground {
                         @Override
                         public void actionPerformed(ActionEvent e) {
                             System.exit(0);
+                        }
+                    });
+
+                    spielStartButton.addActionListener(new ActionListener() {
+
+                        @Override
+                        public void actionPerformed(ActionEvent e) {
+                            SpielfeldPanel.showRandomTilePopup(); ;
                         }
                     });
                     //gameframe.add(label, BorderLayout.CENTER);

--- a/src/main/java/org/example/TileManager.java
+++ b/src/main/java/org/example/TileManager.java
@@ -1,0 +1,15 @@
+package org.example;
+
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class TileManager {
+}


### PR DESCRIPTION
Hi, also ich hab noch mehr Code in die beiden wesentlichen Dateien
Spielfeld.java 
SwingClientWithBackground.java
 eingefügt, um jetzt Kacheln auf das Feld zu kriegen.
Ich glaube CarcasonneGame.java wird generell gar nicht verwendet, das war noch eine frühere Version und den TileManager habe ich auch nicht genommen... 
 
 Alle Funktionen, die die Kacheln abrufen sind in Spielfeld.java. 
Da die main in SwingClientWithBackground.java ist, ist dort eigentlich nur für das Klick-Panel unten ("Nächste Kachel setzen") die Methode, dass ein PopUp mit der nächsten Kachel, die man dann setzen kann, erscheint. 
 
Viel Spaß beim Review und auch beim Mergen :). Da der branch lab-20 auf main aufbaut, kannst du mit lab-20 auch die aktuellste Version des Spiels sehen (wenn du sie dir lokal ziehst).
